### PR TITLE
Use a parameter struct for Rule::evaluate

### DIFF
--- a/cargo-culture-kit/README.md
+++ b/cargo-culture-kit/README.md
@@ -82,7 +82,7 @@ assert_eq!(stats.undetermined_count, 0);
 
 * An example of implementing your own `Rule`:
   ```rust
-  use cargo_culture_kit::{CargoMetadata, Rule, RuleOutcome}
+  use cargo_culture_kit::{CargoMetadata, Rule, RuleContext, RuleOutcome}
   #[derive(Clone, Debug, PartialEq)]
   struct IsProjectAtALuckyTime;
 
@@ -92,10 +92,7 @@ assert_eq!(stats.undetermined_count, 0);
       }
 
       fn evaluate(&self,
-          _cargo_manifest_path: &Path,
-          _verbose: bool,
-          _metadata: &Option<CargoMetadata>,
-          _print_output: &mut Write
+          _context: RuleContext,
       ) -> RuleOutcome {
           use std::time::{SystemTime, UNIX_EPOCH};
           let since_the_epoch = match SystemTime::now().duration_since(UNIX_EPOCH) {

--- a/cargo-culture-kit/src/exit_code.rs
+++ b/cargo-culture-kit/src/exit_code.rs
@@ -42,7 +42,7 @@ impl ExitCode for CheckError {
     fn exit_code(&self) -> i32 {
         match *self {
             CheckError::PrintOutputFailure { .. } => 11,
-            _ => 10
+            _ => 10,
         }
     }
 }
@@ -52,7 +52,7 @@ impl ExitCode for FilterError {
         match *self {
             FilterError::RuleChecklistReadError(_) => 21,
             FilterError::RequestedRuleNotFound { .. } => 22,
-            _ => 20
+            _ => 20,
         }
     }
 }

--- a/cargo-culture-kit/src/rules/builds_cleanly_without_warnings_or_errors.rs
+++ b/cargo-culture-kit/src/rules/builds_cleanly_without_warnings_or_errors.rs
@@ -56,7 +56,7 @@ impl Rule for BuildsCleanlyWithoutWarningsOrErrors {
         build_cmd.arg("build");
         build_cmd
             .arg("--manifest-path")
-            .arg(context.cargo_manifest_file_path);
+            .arg(cargo_manifest_file_path);
         build_cmd.arg("--message-format=json");
         let command_str = format!("{:?}", build_cmd);
         let build_output = match build_cmd.output() {
@@ -66,7 +66,7 @@ impl Rule for BuildsCleanlyWithoutWarningsOrErrors {
             }
         };
         if !build_output.status.success() {
-            if context.verbose {
+            if verbose {
                 let _ = writeln!(print_output, "Build command `{}` failed", command_str);
                 if let Ok(s) = String::from_utf8(build_output.stdout) {
                     let _ = writeln!(print_output, "`{}` StdOut:\n{}\n\n", command_str, s);
@@ -80,7 +80,7 @@ impl Rule for BuildsCleanlyWithoutWarningsOrErrors {
         let stdout = match from_utf8(&build_output.stdout) {
             Ok(stdout) => stdout,
             Err(e) => {
-                if context.verbose {
+                if verbose {
                     let _ = writeln!(
                         print_output,
                         "Reading stdout for command `{}` failed : {}",
@@ -92,7 +92,7 @@ impl Rule for BuildsCleanlyWithoutWarningsOrErrors {
         };
 
         if WARNING_JSON.is_match(stdout) {
-            if context.verbose {
+            if verbose {
                 let _ = writeln!(
                     print_output,
                     "Found warnings in the cargo build command output:\n{}\n\n",

--- a/cargo-culture-kit/src/rules/cargo_metadata_readable.rs
+++ b/cargo-culture-kit/src/rules/cargo_metadata_readable.rs
@@ -1,7 +1,4 @@
-use super::{Rule, RuleOutcome};
-use cargo_metadata::Metadata;
-use std::io::Write;
-use std::path::Path;
+use super::{Rule, RuleContext, RuleOutcome};
 
 /// Rule that asserts a good Rust project:
 /// "Should have a well-formed Cargo.toml file readable by `cargo metadata`"
@@ -23,14 +20,8 @@ impl Rule for CargoMetadataReadable {
     /// and parsed as part of `check_culture` and then handed off to the
     /// `Rule`s being checked, `evaluate` will declare a success if the
     /// `metadata` parameter is `Some`.
-    fn evaluate(
-        &self,
-        _: &Path,
-        _: bool,
-        metadata: &Option<Metadata>,
-        _: &mut Write,
-    ) -> RuleOutcome {
-        match *metadata {
+    fn evaluate(&self, context: RuleContext) -> RuleOutcome {
+        match *context.metadata {
             None => RuleOutcome::Failure,
             Some(_) => RuleOutcome::Success,
         }
@@ -41,6 +32,8 @@ mod tests {
     use super::super::test_support::*;
     use super::*;
     use std::fs::{create_dir_all, File};
+    use std::io::Write;
+    use std::path::Path;
     use tempfile::tempdir;
 
     #[test]

--- a/cargo-culture-kit/src/rules/has_continuous_integration_file.rs
+++ b/cargo-culture-kit/src/rules/has_continuous_integration_file.rs
@@ -1,9 +1,6 @@
 use super::super::file::search_manifest_and_workspace_dir_for_nonempty_file_name_match;
-use super::{Rule, RuleOutcome};
-use cargo_metadata::Metadata;
+use super::{Rule, RuleContext, RuleOutcome};
 use regex::Regex;
-use std::io::Write;
-use std::path::Path;
 
 /// Rule that asserts a good Rust project:
 /// "Should have a file suggesting the use of a continuous integration system."
@@ -29,17 +26,11 @@ impl Rule for HasContinuousIntegrationFile {
         "Should have a file suggesting the use of a continuous integration system."
     }
 
-    fn evaluate(
-        &self,
-        cargo_manifest_file_path: &Path,
-        _verbose: bool,
-        metadata: &Option<Metadata>,
-        _: &mut Write,
-    ) -> RuleOutcome {
+    fn evaluate(&self, context: RuleContext) -> RuleOutcome {
         search_manifest_and_workspace_dir_for_nonempty_file_name_match(
             &HAS_CONTINUOUS_INTEGRATION_FILE,
-            cargo_manifest_file_path,
-            metadata,
+            context.cargo_manifest_file_path,
+            context.metadata,
         )
     }
 }
@@ -48,6 +39,7 @@ mod tests {
     use super::super::test_support::*;
     use super::*;
     use std::fs::File;
+    use std::io::Write;
     use tempfile::tempdir;
 
     fn manual_allowed_set() -> Vec<&'static str> {

--- a/cargo-culture-kit/src/rules/has_contributing_file.rs
+++ b/cargo-culture-kit/src/rules/has_contributing_file.rs
@@ -1,9 +1,6 @@
 use super::super::file::search_manifest_and_workspace_dir_for_nonempty_file_name_match;
-use super::{Rule, RuleOutcome};
-use cargo_metadata::Metadata;
+use super::{Rule, RuleContext, RuleOutcome};
 use regex::Regex;
-use std::io::Write;
-use std::path::Path;
 
 /// Rule that asserts a good Rust project:
 /// "Should have a CONTRIBUTING file in the project directory."
@@ -27,17 +24,11 @@ impl Rule for HasContributingFile {
         "Should have a CONTRIBUTING file in the project directory."
     }
 
-    fn evaluate(
-        &self,
-        cargo_manifest_file_path: &Path,
-        _verbose: bool,
-        metadata: &Option<Metadata>,
-        _print_output: &mut Write,
-    ) -> RuleOutcome {
+    fn evaluate(&self, context: RuleContext) -> RuleOutcome {
         search_manifest_and_workspace_dir_for_nonempty_file_name_match(
             &HAS_CONTRIBUTING_FILE,
-            cargo_manifest_file_path,
-            metadata,
+            context.cargo_manifest_file_path,
+            context.metadata,
         )
     }
 }
@@ -47,6 +38,7 @@ mod tests {
     use super::super::test_support::*;
     use super::*;
     use std::fs::File;
+    use std::io::Write;
     use tempfile::tempdir;
 
     // TODO - Test for workspace style project edge cases

--- a/cargo-culture-kit/src/rules/has_license_file.rs
+++ b/cargo-culture-kit/src/rules/has_license_file.rs
@@ -1,9 +1,6 @@
 use super::super::file::search_manifest_and_workspace_dir_for_nonempty_file_name_match;
-use super::{Rule, RuleOutcome};
-use cargo_metadata::Metadata;
+use super::{Rule, RuleContext, RuleOutcome};
 use regex::Regex;
-use std::io::Write;
-use std::path::Path;
 
 /// Rule that asserts a good Rust project:
 /// "Should have a LICENSE file in the project directory."
@@ -25,17 +22,11 @@ impl Rule for HasLicenseFile {
         "Should have a LICENSE file in the project directory."
     }
 
-    fn evaluate(
-        &self,
-        cargo_manifest_file_path: &Path,
-        _verbose: bool,
-        metadata: &Option<Metadata>,
-        _print_output: &mut Write,
-    ) -> RuleOutcome {
+    fn evaluate(&self, context: RuleContext) -> RuleOutcome {
         search_manifest_and_workspace_dir_for_nonempty_file_name_match(
             &HAS_LICENSE_FILE,
-            cargo_manifest_file_path,
-            metadata,
+            context.cargo_manifest_file_path,
+            context.metadata,
         )
     }
 }
@@ -44,6 +35,7 @@ mod tests {
     use super::super::test_support::*;
     use super::*;
     use std::fs::File;
+    use std::io::Write;
     use tempfile::tempdir;
 
     // TODO - Test for workspace style project edge cases

--- a/cargo-culture-kit/src/rules/has_readme_file.rs
+++ b/cargo-culture-kit/src/rules/has_readme_file.rs
@@ -1,9 +1,6 @@
 use super::super::file::shallow_scan_project_dir_for_nonempty_file_name_match;
-use super::{Rule, RuleOutcome};
-use cargo_metadata::Metadata;
+use super::{Rule, RuleContext, RuleOutcome};
 use regex::Regex;
-use std::io::Write;
-use std::path::Path;
 
 /// Rule that asserts a good Rust project:
 /// "Should have a README.md file in the project directory."
@@ -25,16 +22,10 @@ impl Rule for HasReadmeFile {
         "Should have a README.md file in the project directory."
     }
 
-    fn evaluate(
-        &self,
-        cargo_manifest_file_path: &Path,
-        _verbose: bool,
-        _metadata: &Option<Metadata>,
-        _print_output: &mut Write,
-    ) -> RuleOutcome {
+    fn evaluate(&self, context: RuleContext) -> RuleOutcome {
         shallow_scan_project_dir_for_nonempty_file_name_match(
             &HAS_README_FILE,
-            cargo_manifest_file_path,
+            context.cargo_manifest_file_path,
         )
     }
 }
@@ -44,6 +35,7 @@ mod tests {
     use super::super::test_support::*;
     use super::*;
     use std::fs::File;
+    use std::io::Write;
     use tempfile::tempdir;
 
     #[test]

--- a/cargo-culture-kit/src/rules/has_rustfmt_file.rs
+++ b/cargo-culture-kit/src/rules/has_rustfmt_file.rs
@@ -1,9 +1,6 @@
 use super::super::file::search_manifest_and_workspace_dir_for_nonempty_file_name_match;
-use super::{Rule, RuleOutcome};
-use cargo_metadata::Metadata;
+use super::{Rule, RuleContext, RuleOutcome};
 use regex::Regex;
-use std::io::Write;
-use std::path::Path;
 
 /// Rule that asserts a good Rust project:
 /// "Should have a rustfmt.toml file in the project directory."
@@ -33,17 +30,11 @@ impl Rule for HasRustfmtFile {
         "Should have a rustfmt.toml file in the project directory."
     }
 
-    fn evaluate(
-        &self,
-        cargo_manifest_file_path: &Path,
-        _verbose: bool,
-        metadata: &Option<Metadata>,
-        _print_output: &mut Write,
-    ) -> RuleOutcome {
+    fn evaluate(&self, context: RuleContext) -> RuleOutcome {
         search_manifest_and_workspace_dir_for_nonempty_file_name_match(
             &HAS_RUSTFMT_FILE,
-            cargo_manifest_file_path,
-            metadata,
+            context.cargo_manifest_file_path,
+            context.metadata,
         )
     }
 }
@@ -52,6 +43,7 @@ mod tests {
     use super::super::test_support::*;
     use super::*;
     use std::fs::File;
+    use std::io::Write;
     use tempfile::tempdir;
 
     // TODO - Test for workspace style project edge cases

--- a/cargo-culture-kit/src/rules/uses_property_based_test_library.rs
+++ b/cargo-culture-kit/src/rules/uses_property_based_test_library.rs
@@ -1,8 +1,6 @@
-use super::{Rule, RuleOutcome};
-use cargo_metadata::{DependencyKind, Metadata};
+use super::{Rule, RuleContext, RuleOutcome};
+use cargo_metadata::DependencyKind;
 use regex::Regex;
-use std::io::Write;
-use std::path::Path;
 
 /// Rule that asserts a good Rust project:
 /// "Should be making an effort to use property based tests."
@@ -50,14 +48,8 @@ impl Rule for UsesPropertyBasedTestLibrary {
         "Should be making an effort to use property based tests."
     }
 
-    fn evaluate(
-        &self,
-        _: &Path,
-        _: bool,
-        metadata: &Option<Metadata>,
-        _: &mut Write,
-    ) -> RuleOutcome {
-        match *metadata {
+    fn evaluate(&self, context: RuleContext) -> RuleOutcome {
+        match *context.metadata {
             None => RuleOutcome::Undetermined,
             Some(ref m) => {
                 if m.packages.is_empty() {
@@ -84,6 +76,8 @@ mod tests {
     use super::super::test_support::*;
     use super::*;
     use std::fs::{create_dir_all, File};
+    use std::io::Write;
+    use std::path::Path;
     use tempfile::tempdir;
 
     #[test]


### PR DESCRIPTION
Introduces `RuleContext`, which bundles up the parameters to `Rule::evaluate` for ease of future expansion and to simplify the immediate method signature.  Should resolve: https://github.com/PolySync/cargo-culture/issues/7

I opted for public field member over a fully encapsulated, method-accessed wrapper largely out of a desire for simplicity and a personal prejudice against low-value-added getters stemming from my Java days.

CC: @pittma @mullr @KodrAus 