### PR TITLE
Remove or resolve outstanding TODOs

### DIFF
--- a/cargo-culture-kit/src/checklist.rs
+++ b/cargo-culture-kit/src/checklist.rs
@@ -82,8 +82,6 @@ pub fn find_extant_culture_file(initial_culture_file: &Path) -> Option<PathBuf> 
 ///
 /// Returns a `FilterError::RuleChecklistReadError` error when one of the lines
 /// of the file does not match any of the provided `Rule` descriptions.
-// TODO - probably ought to switch available_rules to be an IntoIterator of
-// some kind to reduce pointless map-to-as_ref-and-collects
 pub fn filter_to_requested_rules_from_checklist_file<'path, 'rules>(
     culture_checklist_file_path: &'path Path,
     available_rules: &'rules [&Rule],
@@ -282,7 +280,10 @@ mod tests {
         assert_eq!(1, filtered_rules.len());
         assert_eq!(
             rule_a.description(),
-            filtered_rules.first().unwrap().description()
+            filtered_rules
+                .first()
+                .expect("Should be at least one thing, per the len")
+                .description()
         );
     }
 

--- a/cargo-culture-kit/src/file.rs
+++ b/cargo-culture-kit/src/file.rs
@@ -108,8 +108,10 @@ mod tests {
             let mut s = String::from("^");
             s.push_str(file_name);
             let r = Regex::new(&s).expect("Could not make trivial prefix regex");
+            // Ignore false positives regarding the Cargo.toml file
+            prop_assume!(!r.is_match("Cargo.toml"));
             let manifest_path = &dir.path().join("Cargo.toml");
-            assert_eq!(
+            prop_assert_eq!(
                 RuleOutcome::Failure,
                 shallow_scan_project_dir_for_nonempty_file_name_match(&r, manifest_path)
             );
@@ -117,7 +119,7 @@ mod tests {
             let mut f = File::create(&file_path).expect("Could not create temp file");
             f.sync_all()
                 .expect("Could not sync temp file state initially");
-            assert_eq!(
+            prop_assert_eq!(
                 RuleOutcome::Failure,
                 shallow_scan_project_dir_for_nonempty_file_name_match(&r, manifest_path)
             );
@@ -125,7 +127,7 @@ mod tests {
                 .expect("Could not write to temp file");
             f.sync_all()
                 .expect("Could not sync temp file state after write");
-            assert_eq!(
+            prop_assert_eq!(
                 RuleOutcome::Success,
                 shallow_scan_project_dir_for_nonempty_file_name_match(&r, manifest_path)
             );
@@ -146,13 +148,15 @@ mod tests {
             let mut s = String::from("^");
             s.push_str(file_name);
             let r = Regex::new(&s).expect("Could not make trivial prefix regex");
+            // Ignore false positives regarding the Cargo.toml file
+            prop_assume!(!r.is_match("Cargo.toml"));
             let metadata = Some(metadata(Some(&child_manifest_path)).expect("Could not get test cargo manifest"));
 
-            assert_eq!(
+            prop_assert_eq!(
                 RuleOutcome::Failure,
                 search_manifest_and_workspace_dir_for_nonempty_file_name_match(&r, &workspace_manifest_path, &metadata)
             );
-            assert_eq!(
+            prop_assert_eq!(
                 RuleOutcome::Failure,
                 search_manifest_and_workspace_dir_for_nonempty_file_name_match(&r, &child_manifest_path, &metadata)
             );
@@ -170,12 +174,12 @@ mod tests {
             target_file.sync_all()
                 .expect("Could not sync temp file state initially");
 
-            assert_eq!(
+            prop_assert_eq!(
                 RuleOutcome::Success,
                 search_manifest_and_workspace_dir_for_nonempty_file_name_match(&r, &child_manifest_path, &metadata)
             );
 
-            assert_eq!(
+            prop_assert_eq!(
                 if *in_kid { RuleOutcome::Failure } else { RuleOutcome::Success },
                 search_manifest_and_workspace_dir_for_nonempty_file_name_match(&r, &workspace_manifest_path, &metadata)
             );

--- a/cargo-culture-kit/src/file.rs
+++ b/cargo-culture-kit/src/file.rs
@@ -3,18 +3,22 @@ use super::RuleOutcome;
 use cargo_metadata::Metadata as CargoMetadata;
 use regex::Regex;
 use std::convert::From;
+use std::fs::read_dir;
 use std::path::{Path, PathBuf};
 
 pub fn shallow_scan_project_dir_for_nonempty_file_name_match(
     regex: &Regex,
     manifest_file_path: &Path,
 ) -> RuleOutcome {
-    use std::fs::read_dir;
     let project_dir = {
         let mut p = manifest_file_path.to_path_buf();
         p.pop();
         p
     };
+    find_nonempty_child_file(regex, &project_dir)
+}
+
+pub fn find_nonempty_child_file(regex: &Regex, project_dir: &Path) -> RuleOutcome {
     if !project_dir.is_dir() {
         return RuleOutcome::Undetermined;
     }

--- a/cargo-culture-kit/src/file.rs
+++ b/cargo-culture-kit/src/file.rs
@@ -1,6 +1,6 @@
 //! File discovery and inspection utilities for use in implementing `Rule`s
 use super::RuleOutcome;
-use cargo_metadata::Metadata;
+use cargo_metadata::Metadata as CargoMetadata;
 use regex::Regex;
 use std::convert::From;
 use std::path::{Path, PathBuf};
@@ -56,7 +56,7 @@ pub fn shallow_scan_project_dir_for_nonempty_file_name_match(
 pub fn search_manifest_and_workspace_dir_for_nonempty_file_name_match(
     regex: &Regex,
     manifest_path: &Path,
-    maybe_metadata: &Option<Metadata>,
+    maybe_metadata: &Option<CargoMetadata>,
 ) -> RuleOutcome {
     let outcome_in_given_manifest_path =
         shallow_scan_project_dir_for_nonempty_file_name_match(regex, manifest_path);
@@ -79,7 +79,7 @@ pub fn search_manifest_and_workspace_dir_for_nonempty_file_name_match(
 
 fn search_metadata_workspace_root_for_file_name_match(
     regex: &Regex,
-    metadata: &Metadata,
+    metadata: &CargoMetadata,
 ) -> RuleOutcome {
     if metadata.workspace_root.is_empty() {
         return RuleOutcome::Undetermined;
@@ -93,36 +93,119 @@ fn search_metadata_workspace_root_for_file_name_match(
 
 #[cfg(test)]
 mod tests {
+    use super::super::rules::test_support::*;
     use super::*;
-    use std::fs::File;
+    use cargo_metadata::metadata;
+    use proptest::prelude::*;
+    use std::fs::{create_dir_all, File};
     use std::io::Write;
-    use tempfile::TempDir;
+    use tempfile::tempdir;
 
-    // TODO - some more direct tests of the search functions,
-    // currently tested indirectly through the rules
-    // that use them
+    proptest! {
+        #[test]
+        fn shallow_scan_finds_arb_file(ref file_name in "[a-zA-Z0-9]+") {
+            let dir = tempdir().expect("Failed to make a temp dir");
+            let mut s = String::from("^");
+            s.push_str(file_name);
+            let r = Regex::new(&s).expect("Could not make trivial prefix regex");
+            let manifest_path = &dir.path().join("Cargo.toml");
+            assert_eq!(
+                RuleOutcome::Failure,
+                shallow_scan_project_dir_for_nonempty_file_name_match(&r, manifest_path)
+            );
+            let file_path = dir.path().join(file_name);
+            let mut f = File::create(&file_path).expect("Could not create temp file");
+            f.sync_all()
+                .expect("Could not sync temp file state initially");
+            assert_eq!(
+                RuleOutcome::Failure,
+                shallow_scan_project_dir_for_nonempty_file_name_match(&r, manifest_path)
+            );
+            f.write_all(b"Hello, world!")
+                .expect("Could not write to temp file");
+            f.sync_all()
+                .expect("Could not sync temp file state after write");
+            assert_eq!(
+                RuleOutcome::Success,
+                shallow_scan_project_dir_for_nonempty_file_name_match(&r, manifest_path)
+            );
+        }
+        #[test]
+        fn search_manifest_and_workspace_dir_for_nonempty_file_name_match_file_lifecycle(
+                ref file_name in "[a-zA-Z0-9]+",
+                ref in_kid in any::<bool>()) {
+
+            let base_dir = tempdir().expect("Failed to make a temp dir");
+            let workspace_manifest_path = base_dir.path().join("Cargo.toml");
+            create_workspace_cargo_toml(&workspace_manifest_path);
+            let subproject_dir = base_dir.path().join("kid");
+            let child_manifest_path = subproject_dir.join("Cargo.toml");
+            create_dir_all(&subproject_dir).expect("Could not create subproject dir");
+            write_package_cargo_toml(&subproject_dir, None);
+            write_clean_src_main_file(&subproject_dir);
+            let mut s = String::from("^");
+            s.push_str(file_name);
+            let r = Regex::new(&s).expect("Could not make trivial prefix regex");
+            let metadata = Some(metadata(Some(&child_manifest_path)).expect("Could not get test cargo manifest"));
+
+            assert_eq!(
+                RuleOutcome::Failure,
+                search_manifest_and_workspace_dir_for_nonempty_file_name_match(&r, &workspace_manifest_path, &metadata)
+            );
+            assert_eq!(
+                RuleOutcome::Failure,
+                search_manifest_and_workspace_dir_for_nonempty_file_name_match(&r, &child_manifest_path, &metadata)
+            );
+
+            let target_file_path = if *in_kid {
+                subproject_dir.join(file_name)
+            } else {
+                base_dir.path().join(file_name)
+            };
+            let mut target_file =
+                File::create(&target_file_path).expect("Could not make target file");
+            target_file
+                .write_all(b"Hello, I am a target file.")
+                .expect("Could not write to target file");
+            target_file.sync_all()
+                .expect("Could not sync temp file state initially");
+
+            assert_eq!(
+                RuleOutcome::Success,
+                search_manifest_and_workspace_dir_for_nonempty_file_name_match(&r, &child_manifest_path, &metadata)
+            );
+
+            assert_eq!(
+                if *in_kid { RuleOutcome::Failure } else { RuleOutcome::Success },
+                search_manifest_and_workspace_dir_for_nonempty_file_name_match(&r, &workspace_manifest_path, &metadata)
+            );
+        }
+    }
 
     #[test]
-    fn file_present_follows_file_lifecycle() {
-        let dir = TempDir::new().unwrap();
+    fn shallow_scan_follows_file_lifecycle() {
+        let dir = tempdir().expect("Failed to make a temp dir");
         let file_path = dir.path().join("foo.txt");
-        let r = Regex::new(r"^fo").unwrap();
+        let r = Regex::new(r"^fo").expect("Could not make trivial prefix regex");
         let manifest_path = &dir.path().join("Cargo.toml");
         assert_eq!(
             RuleOutcome::Failure,
             shallow_scan_project_dir_for_nonempty_file_name_match(&r, manifest_path)
         );
 
-        let mut f = File::create(&file_path).unwrap();
-        f.sync_all().unwrap();
+        let mut f = File::create(&file_path).expect("Could not create temp file");
+        f.sync_all()
+            .expect("Could not sync temp file state initially");
 
         assert_eq!(
             RuleOutcome::Failure,
             shallow_scan_project_dir_for_nonempty_file_name_match(&r, manifest_path)
         );
 
-        f.write_all(b"Hello, world!").unwrap();
-        f.sync_all().unwrap();
+        f.write_all(b"Hello, world!")
+            .expect("Could not write to temp file");
+        f.sync_all()
+            .expect("Could not sync temp file state after write");
         assert_eq!(
             RuleOutcome::Success,
             shallow_scan_project_dir_for_nonempty_file_name_match(&r, manifest_path)
@@ -130,7 +213,4 @@ mod tests {
 
         let _ = dir.close();
     }
-
-    // TODO - force an IO error to observe the Undetermined variant
-    // TODO - explicitly handle directories vs non-directories
 }

--- a/cargo-culture-kit/src/lib.rs
+++ b/cargo-culture-kit/src/lib.rs
@@ -14,11 +14,13 @@
 //! function in combination with the `Rule`s provided by the
 //! `default_rules()` function.
 //!
-//! ```
+//! ```no_run
 //! use cargo_culture_kit::{check_culture_default, IsSuccess, OutcomeStats};
 //! use std::path::PathBuf;
 //!
-//! let cargo_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+//! let cargo_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+//!         .join("Cargo.toml");
+//!
 //! let verbose = false;
 //!
 //! let outcomes = check_culture_default(
@@ -40,7 +42,9 @@
 //! HasLicenseFile}; use std::path::PathBuf;
 //!
 //! let rule = HasLicenseFile::default();
-//! let cargo_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+//! let cargo_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+//!         .join("Cargo.toml");
+//!
 //! let verbose = false;
 //!
 //! let outcomes = check_culture(
@@ -132,11 +136,13 @@ pub enum CheckError {
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// use cargo_culture_kit::{check_culture_default, IsSuccess, OutcomeStats};
 /// use std::path::PathBuf;
 ///
-/// let cargo_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+/// let cargo_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///         .join("Cargo.toml");
+///
 /// let verbose = false;
 ///
 /// let outcomes = check_culture_default(
@@ -144,7 +150,9 @@ pub enum CheckError {
 ///     .expect("Unexpected trouble checking culture rules:");
 ///
 /// for (description, outcome) in &outcomes {
-///     println!("For this project: {} had an outcome of {:?}", description, outcome);
+///     println!(
+///              "For this project: {} had an outcome of {:?}",
+///              description, outcome);
 /// }
 ///
 /// let stats = OutcomeStats::from(outcomes);
@@ -192,7 +200,9 @@ pub fn check_culture_default<P: AsRef<Path>, W: Write>(
 /// HasLicenseFile}; use std::path::PathBuf;
 ///
 /// let rule = HasLicenseFile::default();
-/// let cargo_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+/// let cargo_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///         .join("Cargo.toml");
+///
 /// let verbose = false;
 ///
 /// let outcomes = check_culture(cargo_manifest, verbose, &mut

--- a/cargo-culture-kit/src/rules/cargo_metadata_readable.rs
+++ b/cargo-culture-kit/src/rules/cargo_metadata_readable.rs
@@ -71,19 +71,7 @@ authors = []
         let base_dir = tempdir().expect("Failed to make a temp dir");
         {
             let workspace_cargo_path = base_dir.path().join("Cargo.toml");
-            let mut workspace_cargo_file =
-                File::create(workspace_cargo_path).expect("Could not make workspace Cargo file");
-            workspace_cargo_file
-                .write_all(
-                    br##"
-[workspace]
-
-members = [
-  "kid"
-]
-        "##,
-                )
-                .expect("Could not write to workspace Cargo.toml file");
+            create_workspace_cargo_toml(workspace_cargo_path);
         }
         let subproject_dir = base_dir.path().join("kid");
         create_dir_all(&subproject_dir).expect("Could not create subproject dir");

--- a/cargo-culture-kit/src/rules/has_continuous_integration_file.rs
+++ b/cargo-culture-kit/src/rules/has_continuous_integration_file.rs
@@ -90,13 +90,14 @@ mod tests {
             let mut file = File::create(file_path).expect("Could not make target file");
             file.write_all(b"Hello, I am a CI file.")
                 .expect("Could not write to target file");
+            file.sync_all().expect("Could not sync file");
             let rule = HasContinuousIntegrationFile::default();
             let VerbosityOutcomes {
                 verbose,
                 not_verbose,
             } = execute_rule_against_project_dir_all_verbosities(dir.path(), &rule);
-            assert_eq!(RuleOutcome::Success, verbose.outcome);
-            assert_eq!(RuleOutcome::Success, not_verbose.outcome);
+            prop_assert_eq!(RuleOutcome::Success, verbose.outcome);
+            prop_assert_eq!(RuleOutcome::Success, not_verbose.outcome);
         }
 
         #[test]
@@ -108,13 +109,14 @@ mod tests {
             let mut file = File::create(file_path).expect("Could not make target file");
             file.write_all(b"Hello, I am a CI file.")
                 .expect("Could not write to target file");
+            file.sync_all().expect("Could not sync file");
             let rule = HasContinuousIntegrationFile::default();
             let VerbosityOutcomes {
                 verbose,
                 not_verbose,
             } = execute_rule_against_project_dir_all_verbosities(dir.path(), &rule);
-            assert_eq!(RuleOutcome::Failure, verbose.outcome);
-            assert_eq!(RuleOutcome::Failure, not_verbose.outcome);
+            prop_assert_eq!(RuleOutcome::Failure, verbose.outcome);
+            prop_assert_eq!(RuleOutcome::Failure, not_verbose.outcome);
         }
 
         #[test]
@@ -126,13 +128,14 @@ mod tests {
             let mut file = File::create(file_path).expect("Could not make target file");
             file.write_all(b"Hello, I am a CI file.")
                 .expect("Could not write to target file");
+            file.sync_all().expect("Could not sync file");
             let rule = HasContinuousIntegrationFile::default();
             let VerbosityOutcomes {
                 verbose,
                 not_verbose,
             } = execute_rule_against_project_dir_all_verbosities(dir.path(), &rule);
-            assert_eq!(RuleOutcome::Failure, verbose.outcome);
-            assert_eq!(RuleOutcome::Failure, not_verbose.outcome);
+            prop_assert_eq!(RuleOutcome::Failure, verbose.outcome);
+            prop_assert_eq!(RuleOutcome::Failure, not_verbose.outcome);
         }
     }
 

--- a/cargo-culture-kit/src/rules/has_contributing_file.rs
+++ b/cargo-culture-kit/src/rules/has_contributing_file.rs
@@ -1,6 +1,9 @@
-use super::super::file::search_manifest_and_workspace_dir_for_nonempty_file_name_match;
+use super::super::file::{
+    find_nonempty_child_file, search_manifest_and_workspace_dir_for_nonempty_file_name_match,
+};
 use super::{Rule, RuleContext, RuleOutcome};
 use regex::Regex;
+use std::path::PathBuf;
 
 /// Rule that asserts a good Rust project:
 /// "Should have a CONTRIBUTING file in the project directory."
@@ -25,11 +28,31 @@ impl Rule for HasContributingFile {
     }
 
     fn evaluate(&self, context: RuleContext) -> RuleOutcome {
-        search_manifest_and_workspace_dir_for_nonempty_file_name_match(
+        let initial_outcome = search_manifest_and_workspace_dir_for_nonempty_file_name_match(
             &HAS_CONTRIBUTING_FILE,
             context.cargo_manifest_file_path,
             context.metadata,
-        )
+        );
+        if initial_outcome == RuleOutcome::Success {
+            return RuleOutcome::Success;
+        }
+        let github_dir = {
+            let mut p = context.cargo_manifest_file_path.to_path_buf();
+            p.pop();
+            p.join(".github")
+        };
+        if find_nonempty_child_file(&HAS_CONTRIBUTING_FILE, &github_dir) == RuleOutcome::Success {
+            return RuleOutcome::Success;
+        }
+        if let Some(ref metadata) = context.metadata {
+            let workspace_github_dir = PathBuf::from(&metadata.workspace_root).join(".github");
+            match find_nonempty_child_file(&HAS_CONTRIBUTING_FILE, &workspace_github_dir) {
+                RuleOutcome::Success => RuleOutcome::Success,
+                RuleOutcome::Failure | RuleOutcome::Undetermined => initial_outcome,
+            }
+        } else {
+            initial_outcome
+        }
     }
 }
 
@@ -58,15 +81,48 @@ mod tests {
     }
 
     #[test]
+    fn has_contributing_file_in_dot_github_dir() {
+        let dir = tempdir().expect("Failed to make a temp dir");
+        let github_dir_path = dir.path().join(".github");
+        create_dir_all(&github_dir_path).expect("Could not make .github dir");
+        let file_path = github_dir_path.join("CONTRIBUTING");
+        let mut file = File::create(file_path).expect("Could not make target file");
+        file.write_all(b"Hello, I am a CONTRIBUTING file.")
+            .expect("Could not write to target file");
+        let rule = HasContributingFile::default();
+        let VerbosityOutcomes {
+            verbose,
+            not_verbose,
+        } = execute_rule_against_project_dir_all_verbosities(dir.path(), &rule);
+        assert_eq!(RuleOutcome::Success, verbose.outcome);
+        assert_eq!(RuleOutcome::Success, not_verbose.outcome);
+    }
+
+    #[test]
+    fn has_contributing_file_fails_with_empty_dot_github_dir() {
+        let dir = tempdir().expect("Failed to make a temp dir");
+        let github_dir_path = dir.path().join(".github");
+        create_dir_all(github_dir_path).expect("Could not make .github dir");
+        let rule = HasContributingFile::default();
+        let VerbosityOutcomes {
+            verbose,
+            not_verbose,
+        } = execute_rule_against_project_dir_all_verbosities(dir.path(), &rule);
+        assert_eq!(RuleOutcome::Failure, verbose.outcome);
+        assert_eq!(RuleOutcome::Failure, not_verbose.outcome);
+    }
+
+    #[test]
     fn has_contributing_file_workspace_project_happy_path() {
-        let base_dir = tempdir().expect("Failed to make a temp dir");
-        create_workspace_cargo_toml(base_dir.path().join("Cargo.toml"));
-        let subproject_dir = base_dir.path().join("kid");
-        create_dir_all(&subproject_dir).expect("Could not create subproject dir");
-        write_package_cargo_toml(&subproject_dir, None);
-        write_clean_src_main_file(&subproject_dir);
-        let mut contributing_file =
-            File::create(base_dir.path().join("CONTRIBUTING")).expect("Could not make target file");
+        let workspace_dir = tempdir().expect("Failed to make a temp dir");
+        create_workspace_cargo_toml(workspace_dir.path().join("Cargo.toml"));
+        let kid_dir = workspace_dir.path().join("kid");
+        create_dir_all(&kid_dir).expect("Could not make a kid project dir");
+        write_package_cargo_toml(&kid_dir, None);
+        write_clean_src_main_file(&kid_dir);
+
+        let mut contributing_file = File::create(workspace_dir.path().join("CONTRIBUTING"))
+            .expect("Could not make target file");
         contributing_file
             .write_all(b"Hello, I am a CONTRIBUTING file.")
             .expect("Could not write to target file");
@@ -76,7 +132,7 @@ mod tests {
             let VerbosityOutcomes {
                 verbose,
                 not_verbose,
-            } = execute_rule_against_project_dir_all_verbosities(base_dir.path(), &rule);
+            } = execute_rule_against_project_dir_all_verbosities(workspace_dir.path(), &rule);
             assert_eq!(RuleOutcome::Success, verbose.outcome);
             assert_eq!(RuleOutcome::Success, not_verbose.outcome);
         }
@@ -84,7 +140,42 @@ mod tests {
             let VerbosityOutcomes {
                 verbose,
                 not_verbose,
-            } = execute_rule_against_project_dir_all_verbosities(&subproject_dir, &rule);
+            } = execute_rule_against_project_dir_all_verbosities(&kid_dir, &rule);
+            assert_eq!(RuleOutcome::Success, verbose.outcome);
+            assert_eq!(RuleOutcome::Success, not_verbose.outcome);
+        }
+    }
+    #[test]
+    fn has_contributing_file_workspace_dot_github_happy_path() {
+        let workspace_dir = tempdir().expect("Failed to make a temp dir");
+        create_workspace_cargo_toml(workspace_dir.path().join("Cargo.toml"));
+        let kid_dir = workspace_dir.path().join("kid");
+        create_dir_all(&kid_dir).expect("Could not make a kid project dir");
+        write_package_cargo_toml(&kid_dir, None);
+        write_clean_src_main_file(&kid_dir);
+
+        let github_dir_path = workspace_dir.path().join(".github");
+        create_dir_all(&github_dir_path).expect("Could not make .github dir");
+        let mut contributing_file =
+            File::create(github_dir_path.join("CONTRIBUTING")).expect("Could not make target file");
+        contributing_file
+            .write_all(b"Hello, I am a CONTRIBUTING file.")
+            .expect("Could not write to target file");
+        let rule = HasContributingFile::default();
+
+        {
+            let VerbosityOutcomes {
+                verbose,
+                not_verbose,
+            } = execute_rule_against_project_dir_all_verbosities(workspace_dir.path(), &rule);
+            assert_eq!(RuleOutcome::Success, verbose.outcome);
+            assert_eq!(RuleOutcome::Success, not_verbose.outcome);
+        }
+        {
+            let VerbosityOutcomes {
+                verbose,
+                not_verbose,
+            } = execute_rule_against_project_dir_all_verbosities(&kid_dir, &rule);
             assert_eq!(RuleOutcome::Success, verbose.outcome);
             assert_eq!(RuleOutcome::Success, not_verbose.outcome);
         }

--- a/cargo-culture-kit/src/rules/has_rustfmt_file.rs
+++ b/cargo-culture-kit/src/rules/has_rustfmt_file.rs
@@ -42,11 +42,9 @@ impl Rule for HasRustfmtFile {
 mod tests {
     use super::super::test_support::*;
     use super::*;
-    use std::fs::File;
+    use std::fs::{create_dir_all, File};
     use std::io::Write;
     use tempfile::tempdir;
-
-    // TODO - Test for workspace style project edge cases
 
     #[test]
     fn has_rustfmt_happy_path() {
@@ -62,6 +60,38 @@ mod tests {
         } = execute_rule_against_project_dir_all_verbosities(dir.path(), &rule);
         assert_eq!(RuleOutcome::Success, verbose.outcome);
         assert_eq!(RuleOutcome::Success, not_verbose.outcome);
+    }
+
+    #[test]
+    fn has_rustfmt_file_workspace_project_happy_path() {
+        let base_dir = tempdir().expect("Failed to make a temp dir");
+        create_workspace_cargo_toml(base_dir.path().join("Cargo.toml"));
+        let subproject_dir = base_dir.path().join("kid");
+        create_dir_all(&subproject_dir).expect("Could not create subproject dir");
+        write_package_cargo_toml(&subproject_dir, None);
+        write_clean_src_main_file(&subproject_dir);
+        let mut rustfmt_file = File::create(base_dir.path().join(".rustfmt.toml"))
+            .expect("Could not make target file");
+        rustfmt_file
+            .write_all(b"hard_tabs = true")
+            .expect("Could not write to target file");
+        let rule = HasRustfmtFile::default();
+        {
+            let VerbosityOutcomes {
+                verbose,
+                not_verbose,
+            } = execute_rule_against_project_dir_all_verbosities(base_dir.path(), &rule);
+            assert_eq!(RuleOutcome::Success, verbose.outcome);
+            assert_eq!(RuleOutcome::Success, not_verbose.outcome);
+        }
+        {
+            let VerbosityOutcomes {
+                verbose,
+                not_verbose,
+            } = execute_rule_against_project_dir_all_verbosities(&subproject_dir, &rule);
+            assert_eq!(RuleOutcome::Success, verbose.outcome);
+            assert_eq!(RuleOutcome::Success, not_verbose.outcome);
+        }
     }
 
     #[test]

--- a/cargo-culture-kit/src/rules/mod.rs
+++ b/cargo-culture-kit/src/rules/mod.rs
@@ -148,12 +148,7 @@ pub(crate) mod test_support {
         verbose: bool,
     ) -> OutcomeCapture {
         let cargo_manifest_file_path = project_dir.join("Cargo.toml");
-        let metadata = cargo_metadata::metadata(Some(cargo_manifest_file_path.as_ref()))
-            .map_err(|e| {
-                println!("cargo_metadata error: {:?}", e);
-                e
-            })
-            .ok();
+        let metadata = cargo_metadata::metadata(Some(cargo_manifest_file_path.as_ref())).ok();
         let mut print_output: Vec<u8> = Vec::new();
         let outcome = rule.evaluate(RuleContext {
             cargo_manifest_file_path: &cargo_manifest_file_path,
@@ -188,7 +183,11 @@ authors = []
             writeln!(cargo_file, "{} = \"*\"", extra_dev_dependency)
                 .expect("Could not write extra dev dep to Cargo.toml file");
         }
+        cargo_file
+            .sync_all()
+            .expect("Could not sync package Cargo.toml file");
     }
+
     pub fn create_workspace_cargo_toml<P: AsRef<Path>>(workspace_cargo_path: P) {
         let mut workspace_cargo_file =
             File::create(workspace_cargo_path).expect("Could not make workspace Cargo file");
@@ -203,6 +202,9 @@ members = [
         "##,
             )
             .expect("Could not write to workspace Cargo.toml file");
+        workspace_cargo_file
+            .sync_all()
+            .expect("Could not sync workspace Cargo.toml file");
     }
     pub fn write_clean_src_main_file(project_dir: &Path) {
         let src_dir = project_dir.join("src");
@@ -225,5 +227,6 @@ mod tests {
 }
         "##,
         ).expect("Could not write to target file");
+        file.sync_all().expect("Could not sync main.rs file");
     }
 }

--- a/cargo-culture-kit/src/rules/passes_multiple_tests.rs
+++ b/cargo-culture-kit/src/rules/passes_multiple_tests.rs
@@ -107,7 +107,7 @@ mod tests {
             return;
         }
         let dir = tempdir().expect("Failed to make a temp dir");
-        write_package_cargo_toml(dir.path());
+        write_package_cargo_toml(dir.path(), None);
         write_lib_file_with_dummy_tests(dir.path(), 2);
         let rule = PassesMultipleTests::default();
         let VerbosityOutcomes {
@@ -124,7 +124,7 @@ mod tests {
             return;
         }
         let dir = tempdir().expect("Failed to make a temp dir");
-        write_package_cargo_toml(dir.path());
+        write_package_cargo_toml(dir.path(), None);
         write_lib_file_with_dummy_tests(dir.path(), 10);
         let rule = PassesMultipleTests::default();
         let VerbosityOutcomes {
@@ -141,7 +141,7 @@ mod tests {
             return;
         }
         let dir = tempdir().expect("Failed to make a temp dir");
-        write_package_cargo_toml(dir.path());
+        write_package_cargo_toml(dir.path(), None);
         write_lib_file_with_dummy_tests(dir.path(), 0);
         let rule = PassesMultipleTests::default();
         let VerbosityOutcomes {
@@ -158,7 +158,7 @@ mod tests {
             return;
         }
         let dir = tempdir().expect("Failed to make a temp dir");
-        write_package_cargo_toml(dir.path());
+        write_package_cargo_toml(dir.path(), None);
         write_lib_file_with_dummy_tests(dir.path(), 1);
         let rule = PassesMultipleTests::default();
         let VerbosityOutcomes {
@@ -167,24 +167,6 @@ mod tests {
         } = execute_rule_against_project_dir_all_verbosities(dir.path(), &rule);
         assert_eq!(RuleOutcome::Failure, verbose.outcome);
         assert_eq!(RuleOutcome::Failure, not_verbose.outcome);
-    }
-
-    fn write_package_cargo_toml(project_dir: &Path) {
-        let cargo_path = project_dir.join("Cargo.toml");
-        let mut cargo_file = File::create(cargo_path).expect("Could not make target file");
-        cargo_file
-            .write_all(
-                br##"[package]
-name = "kid"
-version = "0.1.0"
-authors = []
-
-[dependencies]
-
-[dev-dependencies]
-        "##,
-            )
-            .expect("Could not write to Cargo.toml file");
     }
 
     fn write_lib_file_with_dummy_tests(project_dir: &Path, num_tests: usize) {

--- a/cargo-culture-kit/src/rules/uses_property_based_test_library.rs
+++ b/cargo-culture-kit/src/rules/uses_property_based_test_library.rs
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn uses_property_based_test_library_happy_path_flat_project() {
         let dir = tempdir().expect("Failed to make a temp dir");
-        write_package_cargo_toml(dir.path(), "proptest");
+        write_package_cargo_toml(dir.path(), Some("proptest"));
         write_clean_src_main_file(dir.path());
         let rule = UsesPropertyBasedTestLibrary::default();
         let VerbosityOutcomes {
@@ -104,7 +104,7 @@ mod tests {
         #[test]
         fn uses_property_based_test_library_generated(ref name in arb_pbt_dep()) {
             let dir = tempdir().expect("Failed to make a temp dir");
-            write_package_cargo_toml(dir.path(), name);
+            write_package_cargo_toml(dir.path(), Some(name));
             write_clean_src_main_file(dir.path());
             let rule = UsesPropertyBasedTestLibrary::default();
             let VerbosityOutcomes {
@@ -114,27 +114,6 @@ mod tests {
             assert_eq!(RuleOutcome::Success, verbose.outcome);
             assert_eq!(RuleOutcome::Success, not_verbose.outcome);
         }
-    }
-
-    fn write_package_cargo_toml(project_dir: &Path, extra_dev_dependency: &str) {
-        let cargo_path = project_dir.join("Cargo.toml");
-        let mut cargo_file = File::create(cargo_path).expect("Could not make target file");
-        cargo_file
-            .write_all(
-                br##"[package]
-name = "kid"
-version = "0.1.0"
-authors = []
-
-[dependencies]
-
-[dev-dependencies]
-        "##,
-            )
-            .expect("Could not write to Cargo.toml file");
-
-        writeln!(cargo_file, "{} = \"*\"", extra_dev_dependency)
-            .expect("Could not write extra dev dep to Cargo.toml file");
     }
 
     fn write_clean_src_main_file(project_dir: &Path) {


### PR DESCRIPTION
* Removes nonessential TODOs
* Implements essential TODO-listed tasks
* Does an audit of all `unwrap` and `expect` calls.
* Adds support for finding CONTRIBUTING files in a `.github` subdir, a pattern requested by @Dylan-DPC of the Ecosystem working group